### PR TITLE
CDパイプライン構築

### DIFF
--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -2,7 +2,7 @@ name: api-cd
 
 on:
   push:
-    branches: dev/CD_Pipeline
+    branches: main
     paths:
       - 'server/api/**'
       - '.github/**'

--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -1,0 +1,44 @@
+name: api-cd
+
+on:
+  push:
+    branches: dev/CD_Pipeline
+    paths:
+      - 'server/api/**'
+      - '.github/**'
+
+defaults:
+  run:
+    working-directory: server/api
+
+permissions:
+  id-token: write
+  contents: read
+
+  # ECRへのイメージデプロイ
+jobs:
+  deploy-ecr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: true
+      
+      - name: Build and push image to ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/prehnite-api:latest .
+          docker push $ECR_REGISTRY/prehnite-api:latest
+          echo "::set-output name=image::$ECR_REGISTRY/prehnite-api:latest"

--- a/.github/workflows/batch-cd.yml
+++ b/.github/workflows/batch-cd.yml
@@ -2,7 +2,7 @@ name: batch-cd
 
 on:
   push:
-    branches: dev/CD_Pipeline
+    branches: main
     paths:
       - 'server/batch/**'
       - '.github/**'

--- a/.github/workflows/batch-cd.yml
+++ b/.github/workflows/batch-cd.yml
@@ -40,9 +40,18 @@ jobs:
           docker push $ECR_REGISTRY/prehnite-batch:latest
           echo "::set-output name=image::$ECR_REGISTRY/prehnite-batch:latest"
 
-  deploy-ecs:      
+  deploy-ecs:    
     runs-on: ubuntu-latest
+    needs: [deploy-ecr]
     steps:
+      - uses: actions/checkout@v4
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+
       - name: Download task definition
         run: |
           aws ecs describe-task-definition --task-definition prehnite-batch-taskdef --query taskDefinition > task-definition.json

--- a/.github/workflows/batch-cd.yml
+++ b/.github/workflows/batch-cd.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
   contents: read
 
-  # ECRへのイメージデプロイ
+  # ECR/ECSへのイメージデプロイ
 jobs:
   deploy-ecr:
     runs-on: ubuntu-latest
@@ -39,3 +39,17 @@ jobs:
           docker build -t $ECR_REGISTRY/prehnite-batch:latest .
           docker push $ECR_REGISTRY/prehnite-batch:latest
           echo "::set-output name=image::$ECR_REGISTRY/prehnite-batch:latest"
+
+  deploy-ecs:      
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition prehnite-batch-taskdef --query taskDefinition > task-definition.json
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          cluster: prehnite-cluster
+          wait-for-service-stability: true

--- a/.github/workflows/batch-cd.yml
+++ b/.github/workflows/batch-cd.yml
@@ -3,6 +3,9 @@ name: batch-cd
 on:
   push:
     branches: dev/CD_Pipeline
+    paths:
+      - 'server/batch/**'
+      - '.github/**'
 
 defaults:
   run:

--- a/.github/workflows/batch-cd.yml
+++ b/.github/workflows/batch-cd.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
   contents: read
 
-  # ECR/ECSへのイメージデプロイ
+  # ECRへのイメージデプロイ
 jobs:
   deploy-ecr:
     runs-on: ubuntu-latest
@@ -39,26 +39,3 @@ jobs:
           docker build -t $ECR_REGISTRY/prehnite-batch:latest .
           docker push $ECR_REGISTRY/prehnite-batch:latest
           echo "::set-output name=image::$ECR_REGISTRY/prehnite-batch:latest"
-
-  deploy-ecs:    
-    runs-on: ubuntu-latest
-    needs: [deploy-ecr]
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-1
-
-      - name: Download task definition
-        run: |
-          aws ecs describe-task-definition --task-definition prehnite-batch-taskdef --query taskDefinition > task-definition.json
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: task-definition.json
-          cluster: prehnite-cluster
-          wait-for-service-stability: true

--- a/server/api/src/index.ts
+++ b/server/api/src/index.ts
@@ -6,6 +6,12 @@ const app = express();
 app.use(express.json());
 
 app.use("/sound-info", soundInfoRouter);
+app.get("/api/health", async (req, res)=>{
+  return res.json({
+    status: "OK",
+    message: "自動デプロイの成功を確認"
+  })
+})
 
 app.listen(8080, () => {
   console.log(`API Server started...`);


### PR DESCRIPTION
# 行ったこと
Dockerイメージの自動ビルド＆プッシュのみ行い、タスク定義やサービスはそのままというやり方にした
（プッシュするイメージをのタグ値を固定し、上書きされるようにすれば、タスク定義とサービスの変更をせずとも自動デプロイは成功する）