### PR TITLE
APIデプロイ時、ECSのサービスを更新する処理を加えた

### DIFF
--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -42,3 +42,7 @@ jobs:
           docker build -t $ECR_REGISTRY/prehnite-api:latest .
           docker push $ECR_REGISTRY/prehnite-api:latest
           echo "::set-output name=image::$ECR_REGISTRY/prehnite-api:latest"
+
+      - name: Update service
+        run: |
+          aws ecs update-service --cluster prehnite-cluster --service prehnite-api-service --force-new-deployment


### PR DESCRIPTION
今まで、ECRのプッシュのみ行っていた。
バッチ側はそれで反映されるようだが、API側はサービスを更新する処理を加えてあげないといけない模様。