### PR TITLE
フロント　音声検索ページのページ分け

### DIFF
--- a/front/src/components/Footer.tsx
+++ b/front/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export const Footer = () => {
   return (
     <footer className="h-20 bg-neutral-800 border-gray-300 border-t fixed w-full left-0 bottom-0 flex justify-center">
       <div className="h-14 flex items-center justify-around max-w-2xl w-full">
-        <Link href={"/explore"}>
+        <Link href={"/explore/1"}>
           <SearchIcon propClassName="w-9 h-9 p-1 rounded-full stroke-2 hover:bg-neutral-700 transition"></SearchIcon>
         </Link>
         <SettingIcon propClassName="w-9 h-9 p-1 rounded-full stroke-2 hover:bg-neutral-700 transition"></SettingIcon>

--- a/front/src/pages/explore/[page]/index.tsx
+++ b/front/src/pages/explore/[page]/index.tsx
@@ -42,7 +42,9 @@ export const getServerSideProps: GetServerSideProps<SoundsListProps> = async (
   context,
 ) => {
   // APIから音声リストを取得
-  const response = await fetch(`${process.env.API_URL}/sound-info`);
+  const response = await fetch(
+    `${process.env.API_URL}/sound-info/list/${context.params?.page}`,
+  );
   const soundsList: Omit<SoundInfo, "url">[] = await response.json();
 
   return {

--- a/front/src/pages/explore/[page]/index.tsx
+++ b/front/src/pages/explore/[page]/index.tsx
@@ -3,10 +3,10 @@ import { GetServerSideProps } from "next";
 import Image from "next/image";
 import Link from "next/link";
 
-const ExplorePage = ({ soundsList }: SoundsListProps) => {
+const ExplorePage = (props: SoundsListProps) => {
   return (
     <>
-      {soundsList.map((sound) => (
+      {props.soundsList.map((sound) => (
         <Link href={`/play/${sound.id}`} key={sound.id}>
           <div className="h-20 px-4 border-b flex justify-between border-neutral-700 hover:bg-neutral-700 transition">
             <h1 className="font-bold mt-4">{sound.name}</h1>
@@ -32,6 +32,18 @@ const ExplorePage = ({ soundsList }: SoundsListProps) => {
           </div>
         </Link>
       ))}
+      <div className="h-28 pt-4 flex items-start justify-center">
+        <Link href={`/explore/${props.page - 1}`}>
+          <button className="rounded-md px-4 py-2 border border-neutral-700 hover:bg-neutral-700 transition">
+            Prev
+          </button>
+        </Link>
+        <Link href={`/explore/${props.page + 1}`}>
+          <button className="rounded-md px-4 py-2 border border-neutral-700 hover:bg-neutral-700 transition ml-2">
+            Next
+          </button>
+        </Link>
+      </div>
     </>
   );
 };
@@ -50,10 +62,12 @@ export const getServerSideProps: GetServerSideProps<SoundsListProps> = async (
   return {
     props: {
       soundsList,
+      page: Number(context.params?.page),
     },
   };
 };
 
 interface SoundsListProps {
   soundsList: Omit<SoundInfo, "url">[];
+  page: number;
 }

--- a/front/src/pages/explore/[page]/index.tsx
+++ b/front/src/pages/explore/[page]/index.tsx
@@ -15,14 +15,14 @@ const ExplorePage = ({ soundsList }: SoundsListProps) => {
                 (sound.isMaleVoice ? (
                   <Image
                     alt="#"
-                    src={"male_icon.svg"}
+                    src={"/male_icon.svg"}
                     width={32}
                     height={32}
                   ></Image>
                 ) : (
                   <Image
                     alt="#"
-                    src={"female_icon.svg"}
+                    src={"/female_icon.svg"}
                     width={32}
                     height={32}
                   ></Image>

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -16,7 +16,7 @@ const HomePage = () => {
               <br />
               今日も快適な睡眠を...
             </h3>
-            <Link href={"/explore"}>
+            <Link href={"/explore/1"}>
               <button className="mt-6 bg-green-600 hover:bg-green-500 font-bold px-12 py-4 rounded-md transition">
                 <SearchIcon propClassName="w-7 h-7 stroke-2 inline mr-2"></SearchIcon>
                 音声を探す


### PR DESCRIPTION
検索結果を１ページ２０個までの表示とし、２１番目以降は２ページ目、４１番目以降は３ページ目…となるようにした