### PR TITLE
プルダウン変更後の検索処理　修正

### DIFF
--- a/front/src/pages/search/index.tsx
+++ b/front/src/pages/search/index.tsx
@@ -20,7 +20,9 @@ const SearchPage = (props: SoundsListProps) => {
         onSubmit={(e) => {
           e.preventDefault();
           inputRef.current?.blur();
-          router.push(`/search?q=${inputRef.current?.value || ""}`);
+          router.push(
+            `/search?q=${inputRef.current?.value || ""}&sort=${selectRef.current?.value}`,
+          );
         }}
         className="flex justify-center items-center mx-3 my-6"
       >


### PR DESCRIPTION
プルダウン変更後に検索した場合、ソートが解除されてしまう不具合があったため、
ソートを引き付いて検索されるように修正