### PR TITLE
エラーハンドリングの見直し

### DIFF
--- a/api/src/authRouter.ts
+++ b/api/src/authRouter.ts
@@ -73,7 +73,7 @@ authRouter.post(
         return res.status(400).send("メールアドレスが登録済です。");
       }
 
-      return res.status(500).send("Something went wrong in signup...");
+      return res.status(500).send("想定外のエラーが発生しました。");
     }
   },
 );
@@ -124,6 +124,6 @@ authRouter.post("/signin", async (req, res) => {
   } catch (error) {
     console.log("エラー発生");
     console.log(error);
-    return res.status(500).send("Something went wrong in signin...");
+    return res.status(500).send("想定外のエラーが発生しました。");
   }
 });

--- a/api/src/authRouter.ts
+++ b/api/src/authRouter.ts
@@ -3,7 +3,8 @@ import prisma from "./prisma/client";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
-import { body, validationResult } from "express-validator";
+import { body } from "express-validator";
+import { checkReq } from "./middleware/checkReq";
 export const authRouter = express.Router();
 
 // サインアップ
@@ -25,14 +26,8 @@ authRouter.post(
       /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>/?`~])[A-Za-z\d!@#$%^&*()_+\-=\[\]{};':"\\|,.<>/?`~]+$/,
     )
     .withMessage("パスワードの形式が正しくありません。"),
+  checkReq,
   async (req, res) => {
-    // バリデーションチェック
-    const valiResult = validationResult(req);
-    if (!valiResult.isEmpty()) {
-      const valiMsgArray = valiResult.array().map((vali) => vali.msg);
-      return res.status(400).send(valiMsgArray.join(""));
-    }
-
     // 入力値代入
     const name: string = req.body.name;
     const email: string = req.body.email;

--- a/api/src/middleware/checkReq.ts
+++ b/api/src/middleware/checkReq.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from "express";
+import { validationResult } from "express-validator";
+
+export const checkReq = (req: Request, res: Response, next: NextFunction) => {
+  // バリデーションチェック
+  const valiResult = validationResult(req);
+  if (!valiResult.isEmpty()) {
+    const valiMsgArray = valiResult.array().map((vali) => vali.msg);
+    return res.status(400).send(valiMsgArray.join(""));
+  } else {
+    next();
+  }
+};

--- a/api/src/soundInfoRouter.ts
+++ b/api/src/soundInfoRouter.ts
@@ -30,7 +30,7 @@ soundInfoRouter.get("/single/:id", async (req, res) => {
   } catch (error) {
     console.log("エラー発生");
     console.log(error);
-    return res.status(500).send("Something went wrong...");
+    return res.status(500).send("想定外のエラーが発生しました。");
   }
 });
 
@@ -101,6 +101,6 @@ soundInfoRouter.get("/search", async (req, res) => {
   } catch (error) {
     console.log("エラー発生");
     console.log(error);
-    return res.status(500).send("Something went wrong...");
+    return res.status(500).send("想定外のエラーが発生しました。");
   }
 });

--- a/api/src/soundInfoRouter.ts
+++ b/api/src/soundInfoRouter.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import prisma from "./prisma/client";
-import { param } from "express-validator";
+import { param, query } from "express-validator";
 import { checkReq } from "./middleware/checkReq";
 export const soundInfoRouter = express.Router();
 const soundsPerPage = 20;
@@ -8,8 +8,8 @@ const soundsPerPage = 20;
 // 音声情報取得(個別)
 soundInfoRouter.get(
   "/single/:id",
-  param("id").isNumeric().withMessage("音声のIDが数字ではありません。"),
-  checkReq,
+  param("id").isNumeric().withMessage("音声のIDが数字ではありません。"), // リクエストのバリデーション準備
+  checkReq, // リクエストのバリデーションチェック
   async (req, res) => {
     const soundId = Number(req.params.id);
     try {
@@ -39,72 +39,91 @@ soundInfoRouter.get(
 );
 
 // 音声情報取得(一覧)
-soundInfoRouter.get("/search", async (req, res) => {
-  // クエリパラメータpageが存在しない場合、1をセット
-  const currentPage = Number(req.query.page || 1);
-  if (isNaN(currentPage)) {
-    return res.status(400).send("クエリパラメータpageが数字ではありません。");
-  }
-  if (currentPage <= 0) {
-    return res.status(404).send("指定の検索ページが見つかりません。");
-  }
-
-  // クエリパラメータsortの整理
-  const sortBy = String(req.query.sort || "created");
-  let sortCondition: { createdAt: "desc" } | { playCount: "desc" };
-  if (sortBy === "created") {
-    sortCondition = { createdAt: "desc" };
-  } else if (sortBy === "count") {
-    sortCondition = { playCount: "desc" };
-  } else {
-    return res.status(400).send("クエリパラメータsortの指定が正しくありません。");
-  }
-
-  // 検索キーワードを元に検索条件を作成
-  const searchWord = String(req.query.q || "");
-  let wordsConditions: { name: { contains: string } }[] = [];
-  // eslint-disable-next-line no-irregular-whitespace
-  const wordsArray: string[] = searchWord.split(/ |　/);
-  wordsConditions = wordsArray.map((word) => ({
-    name: {
-      contains: word,
-    },
-  }));
-
-  try {
-    // 下記を同時に行う
-    // ・音声情報リストを取得
-    // ・音声情報検索結果 総ページ数
-    const result = await Promise.all([
-      prisma.soundInfo.findMany({
-        where: {
-          AND: [...wordsConditions],
-        },
-        orderBy: sortCondition,
-        take: soundsPerPage,
-        skip: soundsPerPage * (currentPage - 1),
-      }),
-      prisma.soundInfo.count({
-        where: {
-          AND: [...wordsConditions],
-        },
-      }),
-    ]);
-
-    const soundsList = result[0];
-    const totalSounds = result[1];
-    const totalPages =
-      soundsList.length === 0 ? 1 : Math.ceil(totalSounds / soundsPerPage);
-
-    // 検索結果に対して範囲を超えたページ番号が指定された場合、404エラーを出す
-    if (soundsList.length === 0 && currentPage >= 2) {
+soundInfoRouter.get(
+  "/search",
+  // リクエストのバリデーション準備
+  query("page")
+    .custom((page) => {
+      // pageが存在するなら数字文字列であることが正しい
+      if (page && isNaN(page)) {
+        throw new Error();
+      }
+      return true;
+    })
+    .withMessage("クエリパラメータpageが数字ではありません。"),
+  query("sort")
+    .custom((sort) => {
+      // sortが存在するなら"created"もしくは"count"であることが正しい
+      if (sort && !["created", "count"].includes(sort)) {
+        throw new Error();
+      }
+      return true;
+    })
+    .withMessage("クエリパラメータsortの指定が正しくありません。"),
+  checkReq, // リクエストのバリデーションチェック
+  async (req, res) => {
+    // クエリパラメータpageが存在しない場合、1をセット
+    const currentPage = Number(req.query.page || 1);
+    if (currentPage <= 0) {
       return res.status(404).send("指定の検索ページが見つかりません。");
     }
 
-    return res.send({ soundsList, totalPages });
-  } catch (error) {
-    console.log("エラー発生");
-    console.log(error);
-    return res.status(500).send("想定外のエラーが発生しました。");
-  }
-});
+    // クエリパラメータsortの整理
+    const sortBy = String(req.query.sort || "created");
+    let sortCondition: { createdAt: "desc" } | { playCount: "desc" };
+    if (sortBy === "created") {
+      sortCondition = { createdAt: "desc" };
+    } else {
+      // } else if (sortBy === "count") {
+      sortCondition = { playCount: "desc" };
+    }
+
+    // 検索キーワードを元に検索条件を作成
+    const searchWord = String(req.query.q || "");
+    let wordsConditions: { name: { contains: string } }[] = [];
+    // eslint-disable-next-line no-irregular-whitespace
+    const wordsArray: string[] = searchWord.split(/ |　/);
+    wordsConditions = wordsArray.map((word) => ({
+      name: {
+        contains: word,
+      },
+    }));
+
+    try {
+      // 下記を同時に行う
+      // ・音声情報リストを取得
+      // ・音声情報検索結果 総ページ数
+      const result = await Promise.all([
+        prisma.soundInfo.findMany({
+          where: {
+            AND: [...wordsConditions],
+          },
+          orderBy: sortCondition,
+          take: soundsPerPage,
+          skip: soundsPerPage * (currentPage - 1),
+        }),
+        prisma.soundInfo.count({
+          where: {
+            AND: [...wordsConditions],
+          },
+        }),
+      ]);
+
+      const soundsList = result[0];
+      const totalSounds = result[1];
+      const totalPages =
+        soundsList.length === 0 ? 1 : Math.ceil(totalSounds / soundsPerPage);
+
+      // 検索結果に対して範囲を超えたページ番号が指定された場合、404エラーを出す
+      if (soundsList.length === 0 && currentPage >= 2) {
+        return res.status(404).send("指定の検索ページが見つかりません。");
+      }
+
+      return res.send({ soundsList, totalPages });
+    } catch (error) {
+      console.log("エラー発生");
+      console.log(error);
+      return res.status(500).send("想定外のエラーが発生しました。");
+    }
+  },
+);

--- a/api/src/soundInfoRouter.ts
+++ b/api/src/soundInfoRouter.ts
@@ -53,7 +53,7 @@ soundInfoRouter.get("/search", async (req, res) => {
   } else if (sortBy === "count") {
     sortCondition = { playCount: "desc" };
   } else {
-    return res.status(400).send("クエリパラメータsortByの指定が正しくありません。");
+    return res.status(400).send("クエリパラメータsortの指定が正しくありません。");
   }
 
   // 検索キーワードを元に検索条件を作成

--- a/api/src/soundInfoRouter.ts
+++ b/api/src/soundInfoRouter.ts
@@ -7,7 +7,7 @@ const soundsPerPage = 20;
 soundInfoRouter.get("/single/:id", async (req, res) => {
   const soundId = Number(req.params.id);
   if (isNaN(soundId)) {
-    return res.status(400).send("Request Param is not valid...");
+    return res.status(400).send("音声のIDが数字ではありません。");
   }
   try {
     // 音声情報取得
@@ -15,7 +15,7 @@ soundInfoRouter.get("/single/:id", async (req, res) => {
       where: { id: soundId },
     });
     if (!soundInfo) {
-      return res.status(404).send("Sound info was not found...");
+      return res.status(404).send("音声情報が見つかりません。");
     }
     // 再生数加算
     await prisma.soundInfo.update({
@@ -39,10 +39,10 @@ soundInfoRouter.get("/search", async (req, res) => {
   // クエリパラメータpageが存在しない場合、1をセット
   const currentPage = Number(req.query.page || 1);
   if (isNaN(currentPage)) {
-    return res.status(400).send("Request Param is not valid...");
+    return res.status(400).send("クエリパラメータpageが数字ではありません。");
   }
   if (currentPage <= 0) {
-    return res.status(404).send("Page is not found...");
+    return res.status(404).send("指定の検索ページが見つかりません。");
   }
 
   // クエリパラメータsortの整理
@@ -53,7 +53,7 @@ soundInfoRouter.get("/search", async (req, res) => {
   } else if (sortBy === "count") {
     sortCondition = { playCount: "desc" };
   } else {
-    return res.status(400).send("Request Param is not valid...");
+    return res.status(400).send("クエリパラメータsortByの指定が正しくありません。");
   }
 
   // 検索キーワードを元に検索条件を作成
@@ -94,7 +94,7 @@ soundInfoRouter.get("/search", async (req, res) => {
 
     // 検索結果に対して範囲を超えたページ番号が指定された場合、404エラーを出す
     if (soundsList.length === 0 && currentPage >= 2) {
-      return res.status(404).send("Page is not found...");
+      return res.status(404).send("指定の検索ページが見つかりません。");
     }
 
     return res.send({ soundsList, totalPages });

--- a/api/src/test/integration.test.ts
+++ b/api/src/test/integration.test.ts
@@ -63,7 +63,7 @@ describe("Integration test", () => {
 
     // 実行結果
     expect(res.status).toBe(500);
-    expect(res.text).toBe("Something went wrong...");
+    expect(res.text).toBe("想定外のエラーが発生しました。");
   });
 
   test("[正常系1]音声情報を検索(クエリパラメータなし)", async () => {
@@ -165,7 +165,7 @@ describe("Integration test", () => {
 
     // 実行結果
     expect(res.status).toBe(500);
-    expect(res.text).toBe("Something went wrong...");
+    expect(res.text).toBe("想定外のエラーが発生しました。");
   });
 
   // auth
@@ -281,7 +281,7 @@ describe("Integration test", () => {
 
     // 実行結果
     expect(res.status).toBe(500);
-    expect(res.text).toBe("Something went wrong in signup...");
+    expect(res.text).toBe("想定外のエラーが発生しました。");
   });
 
   test("[異常系1]Signin(リクエストパラメータ欠落)", async () => {
@@ -349,6 +349,6 @@ describe("Integration test", () => {
 
     // 実行結果
     expect(res.status).toBe(500);
-    expect(res.text).toBe("Something went wrong in signin...");
+    expect(res.text).toBe("想定外のエラーが発生しました。");
   });
 });

--- a/api/src/test/integration.test.ts
+++ b/api/src/test/integration.test.ts
@@ -35,7 +35,7 @@ describe("Integration test", () => {
 
     // 実行結果
     expect(res.status).toBe(400);
-    expect(res.text).toBe("Request Param is not valid...");
+    expect(res.text).toBe("音声のIDが数字ではありません。");
   });
 
   test("[異常系2]音声情報を個別取得", async () => {
@@ -48,7 +48,7 @@ describe("Integration test", () => {
 
     // 実行結果
     expect(res.status).toBe(404);
-    expect(res.text).toBe("Sound info was not found...");
+    expect(res.text).toBe("音声情報が見つかりません。");
   });
 
   test("[異常系3]音声情報を個別取得", async () => {
@@ -117,7 +117,7 @@ describe("Integration test", () => {
     );
     // 実行結果
     expect(res.status).toBe(400);
-    expect(res.text).toBe("Request Param is not valid...");
+    expect(res.text).toBe("クエリパラメータpageが数字ではありません。");
   });
 
   test("[異常系2]音声情報を検索(検索結果に対しての範囲を超えたページ指定(ページ数を0以下に設定した場合))", async () => {
@@ -127,7 +127,7 @@ describe("Integration test", () => {
     );
     // 実行結果
     expect(res.status).toBe(404);
-    expect(res.text).toBe("Page is not found...");
+    expect(res.text).toBe("指定の検索ページが見つかりません。");
   });
 
   test("[異常系3]音声情報を検索(検索結果に対しての範囲を超えたページ指定(ページ数が大きすぎる場合))", async () => {
@@ -141,7 +141,7 @@ describe("Integration test", () => {
     );
     // 実行結果
     expect(res.status).toBe(404);
-    expect(res.text).toBe("Page is not found...");
+    expect(res.text).toBe("指定の検索ページが見つかりません。");
   });
 
   test("[異常系4]音声情報を検索", async () => {

--- a/api/src/test/integration.test.ts
+++ b/api/src/test/integration.test.ts
@@ -292,9 +292,7 @@ describe("Integration test", () => {
 
     // 実行結果
     expect(res.status).toBe(400);
-    expect(res.text).toBe(
-      "メールアドレスもしくはパスワードが入力されていません。",
-    );
+    expect(res.text).toBe("パスワードが入力されていません。");
   });
 
   test("[異常系2]Signin(emailが存在しない場合)", async () => {

--- a/api/src/test/integration.test.ts
+++ b/api/src/test/integration.test.ts
@@ -144,8 +144,18 @@ describe("Integration test", () => {
     expect(res.text).toBe("指定の検索ページが見つかりません。");
   });
 
-  test("[異常系4]音声情報を検索", async () => {
-    // 異常系1,2,3以外で何らかのエラーが起きた場合を想定
+  test("[異常系4]音声情報を検索(sortByの指定が正しくない)", async () => {
+    // 処理実行
+    const res = await request(app).get(
+      "/sound-info/search?q=test&sort=dummy&page=1",
+    );
+    // 実行結果
+    expect(res.status).toBe(400);
+    expect(res.text).toBe("クエリパラメータsortの指定が正しくありません。");
+  });
+
+  test("[異常系5]音声情報を検索", async () => {
+    // 異常系1,2,3,4以外で何らかのエラーが起きた場合を想定
     // データ設定
     prismaMock.soundInfo.findMany.mockRejectedValue(new Error("Error on Test"));
     prismaMock.soundInfo.count.mockRejectedValue(new Error("Error on Test"));

--- a/batch/src/index.ts
+++ b/batch/src/index.ts
@@ -32,7 +32,7 @@ const main = async () => {
 
     console.log("全処理が完了しました。");
   } catch (error) {
-    console.log("エラー発生");
+    console.log("想定外のエラーが発生しました。");
     console.error(error);
   } finally {
     await prisma.$disconnect();


### PR DESCRIPTION
- api側 400番台エラーメッセージの見直し (前プルリクにて認証処理は400台エラーを日本語にしたため、音声検索処理の400台も日本語に修正)
- api側 500番エラーメッセージの見直し（上に合わせて日本語化）
- api側 リクエストパラメータのバリデーションチェックをexpress-validatorと手作りのミドルウェアを使うことに統一
(ただし、400以外のエラーを返す場合(404等)は対象外)