### PR TITLE
apiでcookieをセットする際、周辺情報を設定するように修正

### DIFF
--- a/api/src/router/authRouter.ts
+++ b/api/src/router/authRouter.ts
@@ -58,7 +58,12 @@ authRouter.post(
         { expiresIn: process.env.JWT_EXPIRE || "24h" },
       );
 
-      res.cookie("token", token);
+      res.cookie("token", token, {
+        httpOnly: true,
+        sameSite: "none",
+        secure: true,
+        path: "/",
+      });
 
       return res.send("OK");
     } catch (error) {
@@ -110,7 +115,12 @@ authRouter.post(
           { expiresIn: process.env.JWT_EXPIRE || "24h" },
         );
 
-        res.cookie("token", token);
+        res.cookie("token", token, {
+          httpOnly: true,
+          sameSite: "none",
+          secure: true,
+          path: "/",
+        });
 
         return res.status(200).send("OK");
       } else {


### PR DESCRIPTION
APIでcookieをセットする際、下記の情報を設定するようにした
・httpOnly: true
・sameSite: "none" (異なるorigin間でcookieを送受信するため)
・secure: true (sameSiteをnoneにすると設定が必要。httpsで通信する必要が出てくる)
・path: "/"