### PR TITLE
ログアウト時、cookieクリアの際に周辺情報を設定するよう修正

### DIFF
--- a/api/src/router/authRouter.ts
+++ b/api/src/router/authRouter.ts
@@ -138,6 +138,11 @@ authRouter.post(
 
 // サインアウト
 authRouter.post("/logout", (req, res) => {
-  res.clearCookie("token");
+  res.clearCookie("token", {
+    httpOnly: true,
+    sameSite: "none",
+    secure: true,
+    path: "/",
+  });
   return res.status(200).send("OK");
 });

--- a/api/src/router/loginUserRouter.ts
+++ b/api/src/router/loginUserRouter.ts
@@ -109,7 +109,12 @@ loginUserRouter.delete(
 
         // Queue情報削除（今後実装する）
 
-        res.clearCookie("token");
+        res.clearCookie("token", {
+          httpOnly: true,
+          sameSite: "none",
+          secure: true,
+          path: "/",
+        });
         return res.status(200).send("OK");
       } else {
         return res.status(400).send("パスワードが正しくありません。");


### PR DESCRIPTION
右記issueの対応 https://github.com/katkatprog/sleepApp/issues/68

ひとまず、「PCのブラウザ（chrome, brave）でログアウト後、リロードするとログイン状態に戻ってしまう（tokenが正しくクリアされない）」のみデプロイしてみて様子を見る