### PR TITLE
89-api-jwtのチェックにおいて中身のuseridが空だった場合も401エラーにしたい

### DIFF
--- a/api/src/middleware/checkJwt.ts
+++ b/api/src/middleware/checkJwt.ts
@@ -19,6 +19,10 @@ export const checkJwt = async (
       process.env.JWT_SECRET || "",
     ) as DecodedToken;
 
+    if (!decoded.userId || typeof decoded.userId !== "number") {
+      return res.status(401).json("認証情報が正しくありません。");
+    }
+
     // 復号したトークンから取り出したuserIdを、後続の関数で使えるようにする
     res.locals.userId = decoded.userId;
 

--- a/api/src/router/loginUserRouter.ts
+++ b/api/src/router/loginUserRouter.ts
@@ -24,6 +24,11 @@ loginUserRouter.get("/", async (req, res) => {
       process.env.JWT_SECRET || "",
     ) as DecodedToken;
 
+    // 復号結果にuserIdが存在しない、数値型ではないなら不正なトークンのため、nullを返す
+    if (!decoded.userId || typeof decoded.userId !== "number") {
+      return res.status(200).json(null);
+    }
+
     loginUserId = decoded.userId;
   } catch (error) {
     return res.status(200).json(null);

--- a/api/src/router/soundRequestRouter.ts
+++ b/api/src/router/soundRequestRouter.ts
@@ -9,10 +9,6 @@ export const soundRequestRouter = express.Router();
 
 // トークンをもとに音声リクエストの状況を取得する
 soundRequestRouter.get("/", checkJwt, async (req, res) => {
-  if (!res.locals.userId) {
-    return res.status(401).send("認証情報が正しくありません。");
-  }
-
   try {
     const queueInfo = await prisma.soundReqQueue.findUnique({
       where: { userId: res.locals.userId as number },
@@ -47,10 +43,6 @@ soundRequestRouter.post(
   checkReq,
   checkJwt,
   async (req, res) => {
-    if (!res.locals.userId) {
-      return res.status(401).send("認証情報が正しくありません。");
-    }
-
     try {
       const queueInfo = await prisma.soundReqQueue.create({
         data: {

--- a/api/src/types/decodedToken.ts
+++ b/api/src/types/decodedToken.ts
@@ -1,5 +1,5 @@
 export interface DecodedToken {
-  userId: number;
+  userId?: unknown;
   iat: number;
   exp: number;
 }


### PR DESCRIPTION
- ミドルウェア（checkJwt.ts）において中身のuserIdが空だった場合、およびuserIdが数値以外だった場合、401エラーにするようにした
- loginuser情報取得（loginUserRouter.ts）においては、userIdが空だった場合、およびuserIdが数値以外だった場合、nullを返すようにした（ログインしていない扱い）