### PR TITLE
issue91 [Front/API] JWT付きでRequestを飛ばす時、BodyにuserIdをセットするのを止めた

### DIFF
--- a/api/src/test/integration.test.ts
+++ b/api/src/test/integration.test.ts
@@ -388,22 +388,9 @@ describe("Integration test", () => {
     expect(res.body).toBe(null);
   });
 
-  test("[異常系]ログインユーザー編集(idが空)", async () => {
-    // 処理実行
-    const res = await request(app).put("/login-user").send({
-      name: "testuser",
-      email: "test@example.com",
-    });
-
-    // 実行結果
-    expect(res.status).toBe(400);
-    expect(res.text).toBe("idが入力されていません。");
-  });
-
   test("[異常系]ログインユーザー編集(nameが空)", async () => {
     // 処理実行
     const res = await request(app).put("/login-user").send({
-      id: 1,
       name: "",
       email: "test@example.com",
     });
@@ -416,7 +403,6 @@ describe("Integration test", () => {
   test("[異常系]ログインユーザー編集(emailが空)", async () => {
     // 処理実行
     const res = await request(app).put("/login-user").send({
-      id: 1,
       name: "testuser",
       email: "",
     });
@@ -428,10 +414,9 @@ describe("Integration test", () => {
     );
   });
 
-  test("[異常系]ログインユーザー編集(emailが空)", async () => {
+  test("[異常系]ログインユーザー編集(emailが不正)", async () => {
     // 処理実行
     const res = await request(app).put("/login-user").send({
-      id: 1,
       name: "testuser",
       email: "test@",
     });
@@ -458,18 +443,15 @@ describe("Integration test", () => {
     expect(res.text).toBe("認証情報が正しくありません。");
   });
 
-  test("[異常系]ログインユーザー削除(id, パスワードが空)", async () => {
+  test("[異常系]ログインユーザー削除(パスワードが空)", async () => {
     // 処理実行
     const res = await request(app).delete("/login-user").send({
-      id: "",
       password: "",
     });
 
     // 実行結果
     expect(res.status).toBe(400);
-    expect(res.text).toBe(
-      "idが入力されていません。パスワードが入力されていません。",
-    );
+    expect(res.text).toBe("パスワードが入力されていません。");
   });
 
   test("[異常系]ログインユーザー削除(tokenが不正)", async () => {
@@ -477,7 +459,6 @@ describe("Integration test", () => {
     const res = await request(app)
       .delete("/login-user")
       .send({
-        id: 1,
         password: "P@ssw0rd",
       })
       .set("Cookie", "dummy");

--- a/front/src/pages/mypage/index.tsx
+++ b/front/src/pages/mypage/index.tsx
@@ -120,7 +120,6 @@ const MyPage = () => {
                                 "content-type": "application/json",
                               },
                               body: JSON.stringify({
-                                // id: context.loginUser.id,
                                 name: nameRef.current?.value,
                                 email: emailRef.current?.value,
                               }),
@@ -220,7 +219,6 @@ const MyPage = () => {
                                 "content-type": "application/json",
                               },
                               body: JSON.stringify({
-                                // id: context.loginUser.id,
                                 password: passwordRef.current?.value,
                               }),
                             },

--- a/front/src/pages/mypage/index.tsx
+++ b/front/src/pages/mypage/index.tsx
@@ -120,7 +120,7 @@ const MyPage = () => {
                                 "content-type": "application/json",
                               },
                               body: JSON.stringify({
-                                id: context.loginUser.id,
+                                // id: context.loginUser.id,
                                 name: nameRef.current?.value,
                                 email: emailRef.current?.value,
                               }),
@@ -220,7 +220,7 @@ const MyPage = () => {
                                 "content-type": "application/json",
                               },
                               body: JSON.stringify({
-                                id: context.loginUser.id,
+                                // id: context.loginUser.id,
                                 password: passwordRef.current?.value,
                               }),
                             },


### PR DESCRIPTION
[従来] ログインユーザー編集・退会において、userIdをJWTとbodyの両方に含めてリクエストしており、
送信先のAPIでJWTのuserIDとbodyのuserIDが一致するかどうかチェックしていた。

[修正後] userIdはJWTのみで送るようにし、JWTのuserIDとbodyのuserIDが一致するかのチェックも排除した