### PR TITLE
アプリアイコンの位置修正

### DIFF
--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -28,7 +28,7 @@ export const Header = () => {
           ></Image>
         </Link>
         {/* ダミー要素 */}
-        <div></div>
+        <div className="w-7"></div>
       </div>
     </header>
   );


### PR DESCRIPTION
ヘッダーにおいて、アプリアイコンが中央から少し右にずれた状態で表示されてしまっていた。
そのため、正確に中央に来るよう修正