### PR TITLE
107 frontフォントの統一

### DIFF
--- a/front/src/pages/_app.tsx
+++ b/front/src/pages/_app.tsx
@@ -24,14 +24,18 @@ export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
     // useEffect内でasync関数を実行するため、即時実行の形にしている
     (async () => {
-      const result = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/login-user/`,
-        {
-          credentials: "include",
-        },
-      );
-      setLoginUser(await result.json());
-      setIsLoading(false);
+      try {
+        const result = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/login-user/`,
+          {
+            credentials: "include",
+          },
+        );
+        setLoginUser(await result.json());
+      } catch (error) {
+      } finally {
+        setIsLoading(false);
+      }
     })();
   }, []);
 

--- a/front/src/pages/_document.tsx
+++ b/front/src/pages/_document.tsx
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html lang="ja">
       <Head />
-      <body className="bg-neutral-800 text-gray-300">
+      <body className="bg-neutral-800 text-gray-300 font-noto-sans-jp">
         <Main />
         <NextScript />
       </body>

--- a/front/src/styles/globals.css
+++ b/front/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
     fontFamily: {
       // Googleフォント「Noto Sans Japanese」の設定
       // クラス名「font-noto-sans-jp」で呼び出せるようになる
-      "noto-sans-jp": ["Noto Sans JP"],
+      "noto-sans-jp": ["Noto\\ Sans\\ JP"],
     },
   },
   plugins: [],

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -14,6 +14,11 @@ const config: Config = {
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
     },
+    fontFamily: {
+      // Googleフォント「Noto Sans Japanese」の設定
+      // クラス名「font-noto-sans-jp」で呼び出せるようになる
+      "noto-sans-jp": ["Noto Sans JP"],
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
アプリ全体のフォントをGoogleフォント「Noto Sans Japanese」に変更。
これにより、OS間のフォント表示の差異を軽減。

ついでに、_app.ts(アプリ全体)でのログインユーザー取得処理も微修正。
取得に失敗した場合、「ログアウトしている」状態として扱えるようにした。