### PR TITLE
ログイン必須ページのログイン誘導方法の修正

### DIFF
--- a/front/src/pages/favorite/index.tsx
+++ b/front/src/pages/favorite/index.tsx
@@ -27,7 +27,7 @@ const FavoritePage = () => {
       );
 
       if (res.status === 401) {
-        router.push("/login");
+        router.push("/login?redirect_to=favorite");
         return;
       }
 

--- a/front/src/pages/login/index.tsx
+++ b/front/src/pages/login/index.tsx
@@ -68,7 +68,11 @@ const LoginPage = () => {
                     userCtx.setLoginUser(await res2.json());
                   }
 
-                  router.push(`/search`);
+                  if (typeof router.query.redirect_to === "string") {
+                    router.push(router.query.redirect_to);
+                  } else {
+                    router.push(`search`);
+                  }
                   toast.success("ログインしました。", { autoClose: 5000 });
                 } catch (error) {
                   processRef.current = false;
@@ -163,7 +167,11 @@ const LoginPage = () => {
                     userCtx.setLoginUser(await res2.json());
                   }
 
-                  router.push(`/search`);
+                  if (typeof router.query.redirect_to === "string") {
+                    router.push(router.query.redirect_to);
+                  } else {
+                    router.push(`search`);
+                  }
                   toast.success("ゲストログインしました。", {
                     autoClose: 5000,
                   });

--- a/front/src/pages/mypage/index.tsx
+++ b/front/src/pages/mypage/index.tsx
@@ -23,7 +23,7 @@ const MyPage = () => {
   useEffect(() => {
     if (!userCtx.isLoading && !userCtx.loginUser) {
       // 未ログイン（ユーザー情報取得が完了、かつその結果が空）の場合、ログインページに移動
-      router.push("login");
+      router.push("/login?redirect_to=mypage");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userCtx.isLoading]);

--- a/front/src/pages/request/index.tsx
+++ b/front/src/pages/request/index.tsx
@@ -23,7 +23,7 @@ const RequestPage = () => {
       );
 
       if (res.status === 401) {
-        router.push("/login");
+        router.push("/login?redirect_to=request");
         return;
       }
 


### PR DESCRIPTION
asis：ログイン必須ページに未ログイン状態でアクセスした場合、ログインページに移動、ログイン後手動でログイン必須ページに再度アクセスする流れだった
tobe：ログイン必須ページに未ログイン状態でアクセスした場合、ログインページに移動、ログイン後自動で先程のログイン必須ページに移動するように修正