### PR TITLE
168 cannot yarn prisma migrate deploy

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 # ----------本番用設定(end)-------------
 
 RUN apk update && apk upgrade
-RUN apk add vim git
+RUN apk add -no-cache openssl
 
 # ----------本番用設定(start)-----------
 RUN yarn

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 # ----------本番用設定(end)-------------
 
 RUN apk update && apk upgrade
-RUN apk add -no-cache openssl
+RUN apk add --no-cache openssl
 
 # ----------本番用設定(start)-----------
 RUN yarn

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,4 +1,4 @@
 FROM node:20-alpine
 WORKDIR "/workspace/api"
 RUN apk update && apk upgrade
-RUN apk add vim git
+RUN apk add --no-cache vim git openssl

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 # ----------本番用設定(end)-------------
 
 RUN apk update && apk upgrade
-RUN apk add vim git python3
+RUN apk add --no-cache openssl python3
 # venvにpykakasiをインストール。&&で繋げる必要がある
 RUN python3 -m venv /path/to/venv && . /path/to/venv/bin/activate && pip3 install pykakasi && deactivate
 

--- a/batch/Dockerfile.dev
+++ b/batch/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 WORKDIR "/workspace/batch"
 RUN apk update && apk upgrade
-RUN apk add vim git python3
+RUN apk add --no-cache vim git openssl python3
 
 # venvにpykakasiをインストール。&&で繋げる必要がある
 RUN python3 -m venv /path/to/venv && . /path/to/venv/bin/activate && pip3 install pykakasi && deactivate


### PR DESCRIPTION
https://github.com/katkatprog/sleepApp/issues/168 に対する修正を実施

https://github.com/prisma/prisma/issues/25817
https://stackoverflow.com/questions/79269631/prisma-openssl-version-issue
を参考に、コンテナビルド時にopensslをインストールするように設定